### PR TITLE
AD won't return an error if you bind with no password

### DIFF
--- a/lib/LdapValidator.js
+++ b/lib/LdapValidator.js
@@ -14,6 +14,8 @@ LdapValidator.prototype.validate = function (username, password, callback) {
     if(err) return callback(err);
     if(!up) return callback();
     var client = ldap.createClient({ url: this._options.url });
+    // AD will bind and delay an error till later if no password is given
+    if(password == '') return callback();
     //try bind by password
     client.bind(up.dn, password, function(err) {
       if(err) return callback();


### PR DESCRIPTION
For example

  var client = ldap.createClient({ url: 'ldap://ldap/', });

  client.bind('CN=user', '', function(err) {
    if(err){ console.log("ERROR"); }
    }
  });

doesn't print anything.

You will get an error at a search etc. But in this case we need to bail out
otherwise we allow users to authenticate with no password!
