### PR TITLE
unbind client

### DIFF
--- a/lib/LdapValidator.js
+++ b/lib/LdapValidator.js
@@ -27,7 +27,10 @@ LdapValidator.prototype.validate = function (username, password, callback) {
     //try bind by password
     client.bind(up.dn, password, function(err) {
       if(err) return callback();
-      callback(null, up);
+      else {
+        client.unbind(); // unbind client to remove process
+        callback(null, up);
+      }
     }.bind(this));
   }.bind(this));
 };


### PR DESCRIPTION
Previously, successive authentication (non integrated) calls resulted in a new process being created each time which ultimately lead to an error once the stack filled up.
