### PR TITLE
Pass socket timeout options to ldap.createClient

### DIFF
--- a/lib/LdapLookup.js
+++ b/lib/LdapLookup.js
@@ -12,7 +12,9 @@ var LdapLookup = module.exports = function(options){
     bindDN:          options.bindDN,
     bindCredentials: options.bindCredentials,
     tlsOptions:      options.tlsOptions,
-    reconnect:       options.reconnect
+    reconnect:       options.reconnect,
+    timeout:         options.timeout,
+    connectTimeout:  options.connectTimeout
   });
 
   this._client.on('error', function(e){


### PR DESCRIPTION
The default ldap client socket timeout options (i.e. infinity) are really not well suited for real-world environments, so allow the caller to override them
