### PR TITLE
Don't log error that ldapjs will handle. Destroy non-reused ldap client

### DIFF
--- a/lib/LdapLookup.js
+++ b/lib/LdapLookup.js
@@ -16,6 +16,9 @@ var LdapLookup = module.exports = function(options){
   });
 
   this._client.on('error', function(e){
+    // Suppress logging of ECONNRESET if ldapjs's Client will automatically reconnect.
+    if (e.errno === 'ECONNRESET' && self._client.reconnect) return;
+
     console.log('LDAP connection error:', e);
   });
 

--- a/lib/LdapValidator.js
+++ b/lib/LdapValidator.js
@@ -26,6 +26,7 @@ LdapValidator.prototype.validate = function (username, password, callback) {
     })
     //try bind by password
     client.bind(up.dn, password, function(err) {
+      if (!this._options.binder) client.destroy();
       if(err) return callback();
       callback(null, up);
     }.bind(this));


### PR DESCRIPTION
1. Don't log ECONNRESET when we know ldapjs will handle it.
2. Destroy non-reused ldap client when validating user/pass.
