### PR TITLE
change pasword check in LdapValidator  to falsei check so  it catches …

### DIFF
--- a/lib/LdapValidator.js
+++ b/lib/LdapValidator.js
@@ -17,7 +17,7 @@ LdapValidator.prototype.validate = function (username, password, callback) {
     if(!up) return callback();
 
     // AD will bind and delay an error till later if no password is given
-    if(password === '') return callback();
+    if(!password) return callback();
 
     var client = this._options.binder || ldap.createClient({
       url:             this._options.url,


### PR DESCRIPTION
in non-integrated if no password is passed the  ldap still validates as the  catch only looks  for  an empty string  but neglects a undefined or null value which the proceeds to validate using a  falsei check solves the isue