### PR TITLE
Prevent LDAP injections by escaping user input

### DIFF
--- a/lib/LdapLookup.js
+++ b/lib/LdapLookup.js
@@ -44,9 +44,15 @@ var LdapLookup = module.exports = function(options){
 LdapLookup.prototype.search = function (username, callback) {
   var self = this;
   function exec(){
+    var escapedUsername = username.replace(/\*/g, '\\2a')
+      .replace(/\(/g, '\\28')
+      .replace(/\)/g, '\\29')
+      .replace(/\\/g, '\\5c')
+      .replace(/\0/g, '\\00')
+      .replace(/\//g, '\\2f');
     var opts = {
       scope: 'sub',
-      filter: self._search_query.replace(/\{0\}/ig, username)
+      filter: self._search_query.replace(/\{0\}/ig, escapedUsername)
     };
     self._client.search(self._options.base, opts, function(err, res){
       var entries = [];


### PR DESCRIPTION
This fixes the possible [LDAP injection](https://en.wikipedia.org/wiki/LDAP_injection) in LdapLookup.search.