### PR TITLE
add option to return id and name in down level logon name format

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -20,6 +20,7 @@ var LdapValidator = require('./LdapValidator');
  *   - `integrated` get the logon name from a trusted header coming from a proxy (IIS or Apache+mod_kerb), as opossed to trying to bind a username and password to LDAP. Defaults to true.
  *   - `getUserNameFromHeader` a func that receives a request object and returns the logon name. x-iisnode-logon_user by default.
  *   - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *   - `downLevelLogonName` when `true` return the id and name in the down level logon name format (https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats)  (default: `false`)
  *
  * Examples:
  *
@@ -70,7 +71,10 @@ function Strategy(options, verify) {
 
   this._getUserNameFromHeader = options.getUserNameFromHeader || function (req) {
     if (!req.headers['x-iisnode-logon_user']) return null;
-    return req.headers['x-iisnode-logon_user'].split('\\')[1];
+
+    return options.downLevelLogonName ? 
+      req.headers['x-iisnode-logon_user'] : 
+      req.headers['x-iisnode-logon_user'].split('\\')[1];
   };
 
   if (options.ldap) {

--- a/test/validations.tests.js
+++ b/test/validations.tests.js
@@ -1,12 +1,90 @@
 var expect = require('chai').expect;
+
 var Strategy = require('../lib/strategy');
+const { assert } = require('chai');
 
 describe('strategy', function () {
-  it('should fail if integrated is false and ldap is null', function(){
-    expect(function() {
+  it('should fail if integrated is false and ldap is null', function () {
+    expect(function () {
       new Strategy({
         integrated: false
-      }, function(){});
+      }, function () { });
     }).to.throw(/ldap url should be provided in order to validate user and passwords/);
+  });
+
+  it('should return downLevelLogonName', function () {
+
+    const domain = 'test-domain';
+    const logonName = 'test-logon';
+    const downLevelLogonName = `${domain}\\${logonName}`;
+    
+    const verify = (up) => {
+      expect(up).to.deep.equal({
+        name: downLevelLogonName,
+        id: downLevelLogonName
+      });
+    }
+
+    const strategy = new Strategy({
+      integrated: true,
+      downLevelLogonName: true,
+    }, verify);
+
+    strategy.authenticate({
+      headers: {
+        'x-iisnode-logon_user': downLevelLogonName
+      }
+    });
+  });
+
+  it('should return logon name if downLevelLogonName is false', function () {
+
+    const domain = 'test-domain';
+    const logonName = 'test-logon';
+    const downLevelLogonName = `${domain}\\${logonName}`;
+    
+    const verify = (up) => {
+      expect(up).to.deep.equal({
+        name: logonName,
+        id: logonName
+      });
+    }
+
+    const strategy = new Strategy({
+      integrated: true,
+      downLevelLogonName: false,
+    }, verify);
+
+
+    strategy.authenticate({
+      headers: {
+        'x-iisnode-logon_user': downLevelLogonName
+      }
+    });
+  });
+
+  it('should return logon name if downLevelLogonName is undefined', function () {
+
+    const domain = 'test-domain';
+    const logonName = 'test-logon';
+    const downLevelLogonName = `${domain}\\${logonName}`;
+    
+    const verify = (up) => {
+      expect(up).to.deep.equal({
+        name: logonName,
+        id: logonName
+      });
+    }
+
+    const strategy = new Strategy({
+      integrated: true
+    }, verify);
+
+
+    strategy.authenticate({
+      headers: {
+        'x-iisnode-logon_user': downLevelLogonName
+      }
+    });
   });
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Allow users to specify the required format of the returned id and name.  Defaults to logonName.  Setting the option 'downLevelLogonName' to a truthy value will return the id and name in [down-level logon name](https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name) format


### References

Issue #49 

### Testing
current functionality and defaults remain unaffected. Setting a new option 'downLevelLogoName' to a truthy value will return the id and name in downLevelLogonName format.

Unit tests have been added to tests/validations.tests.js

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
