### PR TITLE
Fix breaking dependency issue #38 and bug #74 (Mitigates CVE-2022-25896)

### DIFF
--- a/lib/LdapLookup.js
+++ b/lib/LdapLookup.js
@@ -21,7 +21,7 @@ var LdapLookup = module.exports = function(options){
 
   this._client.on('error', function(e){
     // Suppress logging of ECONNRESET if ldapjs's Client will automatically reconnect.
-    if (e.errno === 'ECONNRESET' && self._client.reconnect) return;
+    if (e.code === 'ECONNRESET' && self._client.reconnect) return;
 
     console.log('LDAP connection error:', e);
   });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Auth0",
   "license": "MIT",
   "dependencies": {
-    "passport": "~0.1.15",
+    "passport": "~0.7.0",
     "ldapjs": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
This PR includes 2x single-line fixes for issues #38 and #74.

Fix A resolves or supersedes:
- #38 - <i>Dependency issue</i>
- #68 - <i>Mitigation for CVE-2022-25896 (CWE-384)</i>

Fix B resolves or supersedes:
- #74 - <i>Failure in error check</i>
- #65 - <i>PR that didn't use the template</i>

#### Issue #38
<b>At the present moment, breaking changes in `passport v0.5.1` cause Passport-WindowsAuth to fail authentication completely</b>. This appears to be caused by changes in session handling between `passport` and `express-session`.
<i>More information on that issue can be found in [my comment](https://github.com/auth0/passport-windowsauth/issues/38#issuecomment-2682858001) in issue #38 </i>

This PR fixes the issue by bumping `passport` from `~0.1.15` to `~0.7.0`, which is the latest version at the time of writing.

Code changed:
> `/package.json` lines `21-24`
> ```diff
> @@ -19,7 +19,7 @@
>   "author": "Auth0",
>   "license": "MIT",
>   "dependencies": {
> -    "passport": "~0.1.15",
> +    "passport": "~0.7.0",
>     "ldapjs": "~1.0.0"
>   },
>   "devDependencies": {
> ```

#### Issue #74 
This PR also resolves a bug with an error code check in `/lib/LdapLookup.js` that causes it to check the wrong object key.
<i>More information on that issue can be found in [my comment](https://github.com/auth0/passport-windowsauth/issues/74#issue-2917910535) in issue #74</i>

Code changed:
> `/lib/LdapLookup.js` lines `22-27`
> ```diff
> @@ -21,7 +21,7 @@ var LdapLookup = module.exports = function(options){
> 
>   this._client.on('error', function(e){
>     // Suppress logging of ECONNRESET if ldapjs's Client will automatically reconnect.
> -    if (e.errno === 'ECONNRESET' && self._client.reconnect) return;
> +    if (e.code === 'ECONNRESET' && self._client.reconnect) return;
> 
>     console.log('LDAP connection error:', e);
>   });
> ```

An alternative could have been to change `ECONNRESET` to the error code shown in the console (`-104`), however this would have been less clear to anybody unfamiliar with the codebase.

### References
- Locally
  - #38 - <i>Passport/express-session dependency mismatch</i>
  - #74 - <i>LDAP Connection error check failure</i>
  - #65 - <i>Stale PR that resolves #74</i>
  - #68 - <i>Stale PR that mitigates CVE-2022-25896</i>
- Upstream
  - jaredhanson/passport#939 - <i>Upstream issue about serialization and the passport/express-session dependency mismatch</i>

This PR aims to supersede PR #65 as that PR implements the same fix but did not use the PR template.
This PR also aims to supersede PR #68 as that PR has gone unapproved/unresolved

### Testing
Testing for these changes should be pretty straightforward

#### Testing changes for #38 
At this point in time, if you try to use the examples shown in `readme.md`, Passport-WindowsAuth never responds to the client, nor does it print any errors to the console.

If you're able to successfully authenticate after this PR, you'll know it's working as intended.

#### Testing changes for #74
You'll need to wait for LDAP to receive a <i>connection reset</i> event from the LDAP server. In an Active Directory environment, this should default to 15 minutes or 900 seconds. Once this timeout window occurs, as long as you added `options.reconnect` in your LDAP client settings, you shouldn't see anything in the console. Prior to this PR, you would have seen an error event logged to the console

Example error you shouldn't see:

> `(Console output)`
> ```
> LDAP connection error: Error: read ECONNRESET
>     at TLSWrap.onStreamRead (node:internal/stream_base_commons:216:20) {
>   errno: -104,
>   code: 'ECONNRESET',
>   syscall: 'read'
> }
> ```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
